### PR TITLE
Fix outdated reference to websocket

### DIFF
--- a/leap.go
+++ b/leap.go
@@ -22,7 +22,7 @@ import (
 	"net/url"
 	"os"
 
-	"code.google.com/p/go.net/websocket"
+	"golang.org/x/net/websocket"
 )
 
 const (


### PR DESCRIPTION
From `code.google.com/p/go.net/websocket` to `golang.org/x/net/websocket`.